### PR TITLE
feat: implement warning system for files without ASP tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2025-04-19
+
+### Added
+- New warning system for files without ASP tags instead of treating them as errors
+- Added `--strict` option to treat "no-asp-tags" warnings as errors
+- Added `--ignore-warnings` option to suppress specific warnings (e.g., `--ignore-warnings=no-asp-tags`)
+- Added summary line showing count of skipped files (e.g., "3 files skipped – no ASP tags")
+- Enhanced error type system with `AspErrorKind` enum for better error categorization
+
+### Changed
+- Improved file handling logic now returns more detailed `ParseResult` (Success/Error/Skipped)
+- Refined error and warning messages for better readability
+- Updated tests to comprehensively verify new warning behavior options
+
 ## [0.1.5] - 2025-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "asp-classic-parser"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asp-classic-parser"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 
 [dependencies]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,12 +8,29 @@ use pest_derive::Parser;
 use std::error::Error;
 use std::fmt;
 
+/// Error types for ASP parsing
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AspErrorKind {
+    /// No ASP tags were found in the file
+    NoAspTags,
+    /// Syntax error or other parsing issue
+    ParseError,
+}
+
 /// Custom error type for ASP parsing errors
 #[derive(Debug)]
 pub struct AspParseError {
     message: String,
     line: Option<usize>,
     column: Option<usize>,
+    kind: AspErrorKind,
+}
+
+impl AspParseError {
+    /// Returns true if this error represents a file with no ASP tags
+    pub fn is_no_asp_tags_error(&self) -> bool {
+        self.kind == AspErrorKind::NoAspTags
+    }
 }
 
 impl fmt::Display for AspParseError {
@@ -93,6 +110,7 @@ pub fn parse(input: &str, verbose: bool) -> Result<(), Box<dyn Error>> {
                     message: "No valid ASP tags found in the file".to_string(),
                     line: None,
                     column: None,
+                    kind: AspErrorKind::NoAspTags,
                 }));
             }
 
@@ -110,6 +128,7 @@ pub fn parse(input: &str, verbose: bool) -> Result<(), Box<dyn Error>> {
                 message,
                 line,
                 column,
+                kind: AspErrorKind::ParseError,
             }))
         }
     }


### PR DESCRIPTION
- Add new warning system for files without ASP tags instead of treating them as errors
- Add --strict option to treat no-asp-tags warnings as errors
- Add --ignore-warnings option to suppress specific warnings
- Add summary line showing count of skipped files
- Enhance error type system with AspErrorKind enum
- Update CHANGELOG.md and bump version to 0.1.6
