### PR TITLE
Add --stdin option to parse code directly from standard input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2025-04-19
+
+### Added
+- New `--stdin` / `-s` option to parse code received directly from standard input
+- Improved error reporting when parsing from stdin with appropriate file reference as `<stdin>`
+- Comprehensive tests for stdin parsing capabilities including error handling and "no ASP tags" scenarios
+
+### Changed
+- Clarified usage help text to distinguish between stdin for file list (using `-`) and stdin for code content (using `--stdin`)
+- Enhanced code organization with a dedicated function for parsing stdin content
+
 ## [0.1.8] - 2025-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "asp-classic-parser"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asp-classic-parser"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ cat file_list.txt | asp-classic-parser -
 find . -name "*.asp" | asp-classic-parser -
 ```
 
+### Parse ASP Code Directly from Standard Input
+
+```bash
+# Parse ASP code provided directly through stdin
+echo "<% Response.Write \"Hello World\" %>" | asp-classic-parser --stdin
+
+# Pipe code from a file to be parsed (without reading it as a filename)
+cat code_snippet.asp | asp-classic-parser --stdin
+
+# Use with formatting options
+cat code_snippet.asp | asp-classic-parser --stdin --format=json
+```
+
 ### Exclusion Options
 
 By default, the parser excludes common VCS and tooling directories (.git, .svn, node_modules, etc.). You can customize this behavior:
@@ -173,10 +186,11 @@ The parser maps different types of issues to three severity levels:
 Usage: asp-classic-parser [OPTIONS] [FILES/DIRECTORIES...]
 
 Arguments:
-  [FILES/DIRECTORIES...]  Files or directories to parse (use '-' for stdin)
+  [FILES/DIRECTORIES...]  Files or directories to parse (use '-' for stdin file list)
 
 Options:
   -v, --verbose             Enable verbose output
+  -s, --stdin               Parse ASP code received from standard input
   -f, --format=FORMAT       Output format: ascii (default), ci, json, or auto
       --no-color            Disable colored output in terminal
       --quiet-success       Don't show messages for successfully parsed files


### PR DESCRIPTION
## Description

This PR implements version 0.1.9 of the ASP Classic Parser as described in TODO.md.

### Features Added
- New `--stdin`/`-s` option to parse ASP code received directly from standard input
- Dedicated function to handle stdin content parsing with proper error reporting
- Clear distinction between reading file paths from stdin (using `-`) and parsing code from stdin (using `--stdin`)
- Comprehensive test suite for the new functionality, covering success, error, and 'no-asp-tags' scenarios

### Documentation
- Updated README.md with examples of how to use the new option
- Updated CLI options documentation to include the new parameter
- Added version 0.1.9 details to CHANGELOG.md

### Testing
All tests pass, including the new tests specifically created for the stdin parsing functionality.

This implementation follows the coding standards and conventions specified in the project guidelines.