### PR TITLE
feat(performance): implement parallel file processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.13] - 2025-04-23
+
+### Added
+- Parallel file processing with `--threads N` option for improved performance
+- Automatically detects the number of logical CPU cores and uses them by default
+- Configuration option `threads` in TOML files to set default thread count
+- Thread pool management to prevent excessive resource usage
+- Smart fallback to sequential processing for single files
+
 ## [0.1.12] - 2025-04-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,21 +80,24 @@ dependencies = [
 
 [[package]]
 name = "asp-classic-parser"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "clap",
  "colored",
  "dirs",
  "flate2",
  "libc",
+ "num_cpus",
  "openssl-sys",
  "pest",
  "pest_derive",
+ "rayon",
  "reqwest",
  "semver",
  "serde",
  "serde_json",
  "sha2",
+ "sys-info",
  "tar",
  "tempfile",
  "thiserror 1.0.69",
@@ -306,6 +309,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +394,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -567,6 +595,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hmac"
@@ -941,6 +975,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1186,26 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1431,6 +1495,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asp-classic-parser"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 
 [dependencies]
@@ -22,6 +22,9 @@ zip = "0.6"
 flate2 = "1.0"
 tar = "0.4"
 tempfile = "3.8"  # Added tempfile for temporary directory support
+rayon = "1.8"
+sys-info = "0.9"
+num_cpus = "1.16"
 
 # OpenSSL is now conditionally included based on the target platform
 [target.'cfg(not(windows))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -279,6 +279,38 @@ The cache is stored in your system's cache directory:
 - On macOS: `~/Library/Caches/asp-classic-parser/`
 - On Windows: `%LOCALAPPDATA%\asp-classic-parser\`
 
+### Parallelization Options
+
+The parser supports parallel processing of files to improve performance on multi-core systems:
+
+```bash
+# Use a specific number of threads
+asp-classic-parser directory/ --threads=4
+
+# Let the parser automatically use all available CPU cores (default)
+asp-classic-parser directory/
+
+# Use a single thread (disable parallelization)
+asp-classic-parser directory/ --threads=1
+```
+
+The multi-threading system:
+- Automatically detects the number of logical CPU cores on your system
+- Creates a thread pool sized according to the `--threads` parameter or CPU count
+- Efficiently distributes files across threads for maximum performance
+- Falls back to sequential processing for single files
+- Synchronizes output to prevent interleaved messages
+- Manages shared resources like the parse cache correctly
+- Can be configured in your config file
+
+Example configuration file entry:
+```toml
+# Set default number of threads for parallel processing
+threads = 4
+```
+
+When processing large directories with many files, parallel processing can significantly improve performance.
+
 ### Command Line Options
 
 ```


### PR DESCRIPTION
Add support for multi-threading with --threads option:
- Automatically detect and use available CPU cores by default
- Allow manual thread count configuration via CLI or config file
- Ensure thread-safe access to shared resources like cache and output
- Optimize performance when processing multiple files
- Add comprehensive tests and documentation
